### PR TITLE
Add GHA workflows

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,46 @@
+name: linux
+
+on: 
+  push:
+  pull_request:
+
+jobs:
+
+  build-linux:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: setup
+      run: |
+        sudo apt update
+        cd ../..
+        git clone https://github.com/open-ephys/plugin-GUI.git --branch testing-juce8
+        sudo ./plugin-GUI/Resources/Scripts/install_linux_dependencies.sh
+        cd plugin-GUI/Build && cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+    - name: build
+      run: |
+        cd Build
+        cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+        make
+#    - name: test
+#      run: cd build && ctest
+    - name: deploy
+      if: github.ref == 'refs/heads/main'
+      env:
+        ARTIFACTORY_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+        build_dir: "Build"
+        package: CommutatorControl-linux
+      run: |
+        plugin_api=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]*" | tail -1)
+        tag=$(grep -w Source/OpenEphysLib.cpp -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")
+        new_plugin_ver=$tag-API$plugin_api
+        mkdir plugins 
+        cp -r $build_dir/*.so plugins
+        zipfile=${package}_${new_plugin_ver}.zip
+        zip -r -X $zipfile plugins
+        curl -H "X-JFrog-Art-Api:$ARTIFACTORY_ACCESS_TOKEN" -T $zipfile "https://openephys.jfrog.io/artifactory/CommutatorControl-plugin/linux/$zipfile"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,97 @@
+name: mac
+
+on: 
+  push:
+  pull_request:
+
+jobs:
+
+  build-mac:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: setup
+      run: |
+        cd ../..
+        git clone https://github.com/open-ephys/plugin-GUI.git --branch testing-juce8
+        cd plugin-GUI/Build && cmake -G "Xcode" ..
+    - name: build
+      run: |
+        cd Build
+        cmake -G "Xcode" ..
+        xcodebuild -configuration Release
+#    - name: test
+#      run: cd build && ctest
+    - name: codesign_deploy
+      if: github.ref == 'refs/heads/main'
+      env:
+        ARTIFACTORY_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+        MACOS_CERTIFICATE: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        MACOS_CERTIFICATE_PWD: ${{ secrets.BUILD_CERTIFICATE_PWD }}
+        MACOS_CERTIFICATE_NAME: ${{ secrets.BUILD_CERTIFICATE_NAME }}
+        MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
+        PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+        PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+        PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
+        build_dir: "Build/Release"
+        package: CommutatorControl-mac
+      run: |
+        plugin_api=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]" | tail -1)
+        tag=$(grep -w Source/OpenEphysLib.cpp -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")
+        new_plugin_ver=$tag-API$plugin_api
+
+        mkdir plugins 
+        cp -r $build_dir/*.bundle plugins
+
+        # Turn our base64-encoded certificate back to a regular .p12 file
+        echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+
+        # We need to create a new keychain, otherwise using the certificate will prompt
+        # with a UI dialog asking for the certificate password, which we can't
+        # use in a headless CI environment
+        security create-keychain -p $MACOS_CI_KEYCHAIN_PWD build.keychain
+        security default-keychain -s build.keychain
+        security unlock-keychain -p $MACOS_CI_KEYCHAIN_PWD build.keychain
+        security import certificate.p12 -k build.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_CI_KEYCHAIN_PWD build.keychain
+        /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" -v plugins/oe-commutator-control.bundle --deep --strict --timestamp --options=runtime
+
+        /usr/bin/codesign -dv --verbose=4 plugins/oe-commutator-control.bundle
+
+        # Store the notarization credentials so that we can prevent a UI password dialog from blocking the CI
+
+        echo "Create keychain profile"
+        xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
+
+        # We can't notarize an app bundle directly, but we need to compress it as an archive.
+        # Therefore, we create a zip file containing our app bundle, so that we can send it to the
+        # notarization service
+
+        echo "Creating temp notarization archive"
+        /usr/bin/ditto -c -k --sequesterRsrc --keepParent  plugins/oe-commutator-control.bundle oe-commutator-control.zip
+
+        # Here we send the notarization request to the Apple's Notarization service, waiting for the result.
+        # This typically takes a few seconds inside a CI environment, but it might take more depending on the App
+        # characteristics. Visit the Notarization docs for more information and strategies on how to optimize it if
+        # you're curious
+
+        echo "Notarize app"
+        xcrun notarytool submit "oe-commutator-control.zip" --keychain-profile "notarytool-profile" --wait
+
+        # Finally, we need to "attach the staple" to our executable, which will allow our app to be
+        # validated by macOS even when an internet connection is not available.
+        echo "Attach staple"
+        rm -r plugins/*
+        /usr/bin/ditto -x -k oe-commutator-control.zip plugins
+        xcrun stapler staple plugins/oe-commutator-control.bundle
+
+        spctl -vvv --assess --type exec plugins/oe-commutator-control.bundle
+
+        zipfile=${package}_${new_plugin_ver}.zip
+        /usr/bin/ditto -c -k --sequesterRsrc plugins $zipfile
+        curl -H "X-JFrog-Art-Api:$ARTIFACTORY_ACCESS_TOKEN" -T $zipfile "https://openephys.jfrog.io/artifactory/CommutatorControl-plugin/mac/$zipfile"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,58 @@
+name: Windows
+
+on: 
+  push:
+  pull_request:
+
+jobs:
+
+  build-windows:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+    
+    steps:
+    - uses: actions/checkout@v4
+    - name: setup
+      run: |
+        cd ../..
+        git clone https://github.com/open-ephys/plugin-GUI.git --branch testing-juce8
+        cd plugin-GUI/Build
+        cmake -G "Visual Studio 17 2022" -A x64 .. 
+        mkdir Release && cd Release
+        curl -L https://openephys.jfrog.io/artifactory/GUI-binaries/Libraries/open-ephys-lib-v1.0.0-alpha.zip --output open-ephys-lib.zip
+        unzip open-ephys-lib.zip
+      shell: bash
+    - name: configure
+      run: |
+        cd Build
+        cmake -G "Visual Studio 17 2022" -A x64 .. 
+      shell: bash
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v2
+    - name: build-plugin
+      run: |
+        cd Build
+        msbuild INSTALL.vcxproj -p:Configuration=Release -p:Platform=x64
+      shell: cmd
+# TODO: Perform some basic testing before publishing...
+#    - name: test
+#      run: cd build && ctest
+    - name: deploy
+      if: github.ref == 'refs/heads/main'
+      env:
+        ARTIFACTORY_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+        build_dir: "Build/Release"
+        package: CommutatorControl-windows
+      run: |
+        plugin_api=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]*" | tail -1)
+        tag=$(grep -w Source/OpenEphysLib.cpp -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")
+        new_plugin_ver=$tag-API$plugin_api
+        mkdir plugins
+        cp $build_dir/*.dll plugins
+        zipfile=${package}_${new_plugin_ver}.zip
+        powershell Compress-Archive -Path "plugins" -DestinationPath ${zipfile}
+        curl -H "X-JFrog-Art-Api:$ARTIFACTORY_ACCESS_TOKEN" -T $zipfile "https://openephys.jfrog.io/artifactory/CommutatorControl-plugin/windows/$zipfile"
+      shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.15)
 if (NOT DEFINED GUI_BASE_DIR)
 	if (DEFINED ENV{GUI_BASE_DIR})
 		set(GUI_BASE_DIR $ENV{GUI_BASE_DIR})
@@ -78,7 +78,7 @@ elseif(APPLE)
 	set_property(TARGET ${PLUGIN_NAME} APPEND_STRING PROPERTY LINK_FLAGS
 	"-undefined dynamic_lookup -rpath @loader_path/../../../../shared")
 
-	install(TARGETS ${PLUGIN_NAME} DESTINATION $ENV{HOME}/Library/Application\ Support/open-ephys/plugins-api8)
+	install(TARGETS ${PLUGIN_NAME} DESTINATION $ENV{HOME}/Library/Application\ Support/open-ephys/plugins-api9)
 	set(CMAKE_PREFIX_PATH /opt/local)
 endif()
 

--- a/Source/CommutatorThread.cpp
+++ b/Source/CommutatorThread.cpp
@@ -82,6 +82,7 @@ bool CommutatorThread::start()
     {
         startTimer (100);
         isRunning = true;
+        return true;
     }
     else
     {

--- a/Source/OECommutator.cpp
+++ b/Source/OECommutator.cpp
@@ -26,7 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <CoreServicesHeader.h>
 
 OECommutator::OECommutator()
-    : GenericProcessor ("OE Commutator")
+    : GenericProcessor ("Commutator Control")
 {
     addIntParameter (Parameter::PROCESSOR_SCOPE, "current_stream", "Current Stream", "Currently selected stream", 0, 0, 200000, false);
 

--- a/Source/OECommutator.cpp
+++ b/Source/OECommutator.cpp
@@ -28,6 +28,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 OECommutator::OECommutator()
     : GenericProcessor ("Commutator Control")
 {
+    commutator = std::make_unique<CommutatorThread>();
+
+    channelIndices.fill (-1);
+}
+
+void OECommutator::registerParameters()
+{
     addIntParameter (Parameter::PROCESSOR_SCOPE, "current_stream", "Current Stream", "Currently selected stream", 0, 0, 200000, false);
 
     addStringParameter (Parameter::PROCESSOR_SCOPE, "serial_name", "Serial Name", "Serial port name", "", true);
@@ -41,10 +48,6 @@ OECommutator::OECommutator()
     axes.add ("-X");
 
     addCategoricalParameter (Parameter::PROCESSOR_SCOPE, "axis", "Axis", "Selected axis", axes, 0, true);
-
-    commutator = std::make_unique<CommutatorThread>();
-
-    channelIndices.fill (-1);
 }
 
 AudioProcessorEditor* OECommutator::createEditor()

--- a/Source/OECommutator.cpp
+++ b/Source/OECommutator.cpp
@@ -35,19 +35,9 @@ OECommutator::OECommutator()
 
 void OECommutator::registerParameters()
 {
-    addIntParameter (Parameter::PROCESSOR_SCOPE, "current_stream", "Current Stream", "Currently selected stream", 0, 0, 200000, false);
+    addIntParameter (Parameter::PROCESSOR_SCOPE, "current_stream", "Current Stream", "Currently selected stream", 0, 0, 200000, true);
 
     addStringParameter (Parameter::PROCESSOR_SCOPE, "serial_name", "Serial Name", "Serial port name", "", true);
-
-    Array<String> axes = Array<String>();
-    axes.add ("+Z");
-    axes.add ("-Z");
-    axes.add ("+Y");
-    axes.add ("-Y");
-    axes.add ("+X");
-    axes.add ("-X");
-
-    addCategoricalParameter (Parameter::PROCESSOR_SCOPE, "axis", "Axis", "Selected axis", axes, 0, true);
 }
 
 AudioProcessorEditor* OECommutator::createEditor()
@@ -68,12 +58,14 @@ void OECommutator::parameterValueChanged (Parameter* parameter)
     else if (parameter->getName().equalsIgnoreCase ("serial_name"))
     {
         commutator->setSerial (parameter->getValueAsString());
+        ((OECommutatorEditor*) editor.get())->setSerialSelection (parameter->getValueAsString().toStdString());
     }
 }
 
 bool OECommutator::isReady()
 {
-    commutator->setRotationAxis (getRotationAxis (getParameter ("axis")->getValueAsString()));
+    std::string axis = ((OECommutatorEditor*) editor.get())->getAxisSelection();
+    commutator->setRotationAxis (getRotationAxis (axis));
 
     if (! commutator->isReady())
         return false;
@@ -168,6 +160,17 @@ Vector3D<double> OECommutator::getRotationAxis (String axis) const
     {
         return Vector3D<double> (0, 0, 0);
     }
+}
+
+int OECommutator::getAxisIndex (std::string axis)
+{
+    for (int i = 0; i < axes.size(); i++)
+    {
+        if (axis == axes[i])
+            return i;
+    }
+
+    return -1;
 }
 
 void OECommutator::setChannelIndices (std::array<int, NUM_QUATERNION_CHANNELS> indices)

--- a/Source/OECommutator.cpp
+++ b/Source/OECommutator.cpp
@@ -188,4 +188,5 @@ bool OECommutator::verifyQuaternionChannelIndices (std::array<int, NUM_QUATERNIO
                 return false;
         }
     }
+    return true;
 }

--- a/Source/OECommutator.h
+++ b/Source/OECommutator.h
@@ -33,6 +33,8 @@ public:
 
     ~OECommutator() {};
 
+    void registerParameters() override;
+
     AudioProcessorEditor* createEditor() override;
 
     void process (AudioBuffer<float>& buffer) override;

--- a/Source/OECommutator.h
+++ b/Source/OECommutator.h
@@ -59,13 +59,18 @@ public:
         Z = 3,
     };
 
+    inline static const std::array<std::string, 6> axes = { "+Z", "-Z", "+Y", "-Y", "+X", "-X" };
+
     /** Sets the quaternion channel indices within a specific stream. Quaternion indices are expected to be ordered X/Y/Z/W. */
     void setChannelIndices (std::array<int, NUM_QUATERNION_CHANNELS> indices);
 
     /** Check that all indices are unique, and greater than or equal to zero. */
     static bool verifyQuaternionChannelIndices (std::array<int, NUM_QUATERNION_CHANNELS> indices);
 
+    static int getAxisIndex (std::string axis);
+
 private:
+
     uint16 currentStream = 0;
     std::unique_ptr<CommutatorThread> commutator;
 

--- a/Source/OECommutator.h
+++ b/Source/OECommutator.h
@@ -51,7 +51,7 @@ public:
 
     static constexpr int NUM_QUATERNION_CHANNELS = 4;
 
-    static enum class QuaternionChannel : uint32_t
+    enum class QuaternionChannel : uint32_t
     {
         W = 0,
         X = 1,

--- a/Source/OECommutatorEditor.cpp
+++ b/Source/OECommutatorEditor.cpp
@@ -26,17 +26,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 OECommutatorEditor::OECommutatorEditor (GenericProcessor* parentNode)
     : GenericEditor (parentNode)
 {
-    desiredWidth = 180;
+    desiredWidth = 185;
 
     vector<ofSerialDeviceInfo> devices = serial.getDeviceList();
 
+    FontOptions labelFont("Inter", "Regular", 14.0f);
+
     serialLabel = std::make_unique<Label> ("Serial label");
+    serialLabel->setFont (labelFont);
     serialLabel->setText ("Serial port", dontSendNotification);
-    serialLabel->setBounds (5, 30, 90, 20);
+    serialLabel->setBounds (10, 30, 90, 20);
     addAndMakeVisible (serialLabel.get());
 
     serialSelection = std::make_unique<ComboBox> ("Serial");
-    serialSelection->setBounds (5, 50, 90, 20);
+    serialSelection->setBounds (10, 50, 90, 20);
+    serialSelection->setTextWhenNothingSelected ("Select a port");
     for (int i = 0; i < devices.size(); i++)
     {
         serialSelection->addItem (devices[i].getDevicePath(), i + 1);
@@ -45,7 +49,7 @@ OECommutatorEditor::OECommutatorEditor (GenericProcessor* parentNode)
     addAndMakeVisible (serialSelection.get());
 
     axisOverride = std::make_unique<UtilityButton> ("Override");
-    axisOverride->setBounds (110, 30, 62, 18);
+    axisOverride->setBounds (115, 30, 62, 18);
     axisOverride->setRadius (2.0f);
     axisOverride->setClickingTogglesState (true);
     axisOverride->setToggleState (false, dontSendNotification);
@@ -55,33 +59,36 @@ OECommutatorEditor::OECommutatorEditor (GenericProcessor* parentNode)
 
     axisSelection = std::make_unique<ComboBoxParameterEditor> (parentNode->getParameter ("axis"));
     axisSelection->setLayout (ParameterEditor::Layout::nameHidden);
-    axisSelection->setBounds (110, 50, 62, 20);
+    axisSelection->setBounds (115, 50, 62, 20);
     axisSelection->setEnabled (axisOverride->getToggleState());
     addAndMakeVisible (axisSelection.get());
 
     streamLabel = std::make_unique<Label> ("Stream label");
+    streamLabel->setFont (labelFont);
     streamLabel->setText ("Stream", dontSendNotification);
-    streamLabel->setBounds (5, 75, 90, 20);
+    streamLabel->setBounds (10, 75, 90, 20);
     addAndMakeVisible (streamLabel.get());
 
     streamSelection = std::make_unique<ComboBox> ("Stream");
-    streamSelection->setBounds (5, 95, 90, 20);
+    streamSelection->setBounds (10, 95, 90, 20);
     streamSelection->addListener (this);
     addAndMakeVisible (streamSelection.get());
 
     manualTurnLabel = std::make_unique<Label> ("manualTurn");
+    manualTurnLabel->setFont (labelFont);
     manualTurnLabel->setText ("Turn", dontSendNotification);
-    manualTurnLabel->setBounds (118, 75, 50, 20);
+    manualTurnLabel->setJustificationType (Justification::centred);
+    manualTurnLabel->setBounds (122, 75, 45, 20);
     addAndMakeVisible (manualTurnLabel.get());
 
     leftButton = std::make_unique<ArrowButton> ("left", 0.5f, juce::Colours::black);
-    leftButton->setBounds (117, 95, 20, 20);
+    leftButton->setBounds (122, 95, 20, 20);
     leftButton->addListener (this);
     leftButton->setRepeatSpeed (500, 100);
     addAndMakeVisible (leftButton.get());
 
     rightButton = std::make_unique<ArrowButton> ("right", 0.0f, juce::Colours::black);
-    rightButton->setBounds (142, 95, 20, 20);
+    rightButton->setBounds (147, 95, 20, 20);
     rightButton->addListener (this);
     rightButton->setRepeatSpeed (500, 100);
     addAndMakeVisible (rightButton.get());

--- a/Source/OECommutatorEditor.h
+++ b/Source/OECommutatorEditor.h
@@ -45,10 +45,18 @@ public:
     void startAcquisition() override;
     void stopAcquisition() override;
 
+    void saveCustomParametersToXml (XmlElement* xml) override;
+    void loadCustomParametersFromXml (XmlElement* xml) override;
+
+    void setSerialSelection (std::string selection);
+
+    std::string getAxisSelection();
+
 private:
+
     ofSerial serial;
 
-    std::unique_ptr<ComboBoxParameterEditor> axisSelection;
+    std::unique_ptr<ComboBox> axisSelection;
 
     std::unique_ptr<ComboBox> serialSelection;
     std::unique_ptr<ComboBox> streamSelection;

--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -39,7 +39,7 @@ using namespace Plugin;
 extern "C" EXPORT void getLibInfo (Plugin::LibraryInfo* info)
 {
     info->apiVersion = PLUGIN_API_VER;
-    info->name = "Open Ephys commutator control";
+    info->name = "Commutator Control";
     info->libVersion = "0.1.0";
     info->numPlugins = NUM_PLUGINS;
 }
@@ -50,7 +50,7 @@ extern "C" EXPORT int getPluginInfo (int index, Plugin::PluginInfo* info)
     {
         case 0:
             info->type = Plugin::Type::PROCESSOR;
-            info->processor.name = "OE Commutator"; //Processor name shown in the GUI
+            info->processor.name = "Commutator Control"; //Processor name shown in the GUI
             info->processor.type = Processor::Type::SINK;
             info->processor.creator = &(Plugin::createProcessor<OECommutator>);
             break;


### PR DESCRIPTION
* Added GitHub Actions workflows for Linux, macOS, and Windows to automate building, packaging, and deploying the plugin. (Currently builds off of `testing-juce8` branch of plugin-GU)
* Updated the plugin library and processor name from "OE Commutator" to "Commutator Control"
* Updated the layout and fonts of the plugin editor
* Updated processor to create parameters inside the `registerParameters` function
* Fixed build errors on Linux and a few compiler warnings