### PR TITLE
Set the default axis to be +Z

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -41,7 +41,7 @@ jobs:
         build_dir: "Build/Release"
         package: CommutatorControl-mac
       run: |
-        plugin_api=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]" | tail -1)
+        plugin_api=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]*" | tail -1)
         tag=$(grep -w Source/OpenEphysLib.cpp -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")
         new_plugin_ver=$tag-API$plugin_api
 

--- a/Source/OECommutatorEditor.cpp
+++ b/Source/OECommutatorEditor.cpp
@@ -66,7 +66,7 @@ OECommutatorEditor::OECommutatorEditor (GenericProcessor* parentNode)
     {
         axisSelection->addItem (axis, count++);
     }
-    axisSelection->setSelectedItemIndex (1, dontSendNotification);
+    axisSelection->setSelectedItemIndex (0, dontSendNotification);
     axisSelection->addListener (this);
     addAndMakeVisible (axisSelection.get());
 

--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -40,7 +40,7 @@ extern "C" EXPORT void getLibInfo (Plugin::LibraryInfo* info)
 {
     info->apiVersion = PLUGIN_API_VER;
     info->name = "Commutator Control";
-    info->libVersion = "1.0.0";
+    info->libVersion = "1.0.1";
     info->numPlugins = NUM_PLUGINS;
 }
 


### PR DESCRIPTION
At f4006cf, I incorrectly set the default axis to be -Z instead of +Z due to the inconsistency in Juce between zero-indexed and one-indexed methods.