### PR TITLE
New turn algorighm

### DIFF
--- a/Source/CommutatorThread.cpp
+++ b/Source/CommutatorThread.cpp
@@ -115,17 +115,17 @@ void CommutatorThread::sendTurn (double turn)
 
 double CommutatorThread::quaternionToTwist (Quaternion<double> currentQuaternion, Quaternion<double> lastQuaternion)
 {
-    Quaternion<double> lastTransposed(-lastQuaternion.vector, lastQuaternion.scalar);
+    Quaternion<double> lastConjugated(-lastQuaternion.vector, lastQuaternion.scalar);
 
     // Get incremental rotation
     Quaternion<double> deltaQuaternion(currentQuaternion);
-    deltaQuaternion *= lastTransposed; //juce quaternions do not implement a*b operator, only a *= b.
+    deltaQuaternion *= lastConjugated; //juce quaternions do not implement a*b operator, only a *= b.
 
     // Get device rotation axis in global coordinates
     Quaternion<double> deviceAxis (rotationAxis, 0);
     Quaternion<double> projection (lastQuaternion);
     projection *= deviceAxis;
-    projection *= lastTransposed;
+    projection *= lastConjugated;
 
 
     // Calculate rotation across the axis in global coordinates
@@ -133,7 +133,7 @@ double CommutatorThread::quaternionToTwist (Quaternion<double> currentQuaternion
 
     double incrementalAngle = 2*std::atan2 (dotProduct, deltaQuaternion.scalar);
 
-    return incrementalAngle / MathConstants<double>::twoPi;
+    return -incrementalAngle / MathConstants<double>::twoPi;
 
 }
 

--- a/Source/CommutatorThread.cpp
+++ b/Source/CommutatorThread.cpp
@@ -75,7 +75,7 @@ bool CommutatorThread::isReady() const
 bool CommutatorThread::start()
 {
     lastTwist = std::numeric_limits<double>::quiet_NaN();
-    previousAngleAboutAxis = std::numeric_limits<double>::quiet_NaN();
+    lastQuaternion = defaultQuaternion;
     runningQuaternion = defaultQuaternion;
 
     if (open && rotationAxis.length() == 1)
@@ -113,32 +113,28 @@ void CommutatorThread::sendTurn (double turn)
     int n = serial.writeBytes (reinterpret_cast<unsigned char*> (const_cast<char*> (str)), len);
 }
 
-double CommutatorThread::quaternionToTwist (Quaternion<double> quaternion)
+double CommutatorThread::quaternionToTwist (Quaternion<double> currentQuaternion, Quaternion<double> lastQuaternion)
 {
-    // Project rotation axis onto the direction axis
-    double dotProduct = quaternion.vector * rotationAxis;
+    Quaternion<double> lastTransposed(-lastQuaternion.vector, lastQuaternion.scalar);
 
-    Vector3D<double> projection = rotationAxis;
-    double scaleFactor = dotProduct / (rotationAxis * rotationAxis);
-    projection *= scaleFactor;
+    // Get incremental rotation
+    Quaternion<double> deltaQuaternion(currentQuaternion);
+    deltaQuaternion *= lastTransposed; //juce quaternions do not implement a*b operator, only a *= b.
 
-    Quaternion<double> rotationAboutAxis = Quaternion<double> (projection, quaternion.scalar).normalised();
+    // Get device rotation axis in global coordinates
+    Quaternion<double> deviceAxis (rotationAxis, 0);
+    Quaternion<double> projection (lastQuaternion);
+    projection *= deviceAxis;
+    projection *= lastTransposed;
 
-    if (dotProduct < 0) // Account for angle-axis flipping
-    {
-        rotationAboutAxis = Quaternion<double> (-rotationAboutAxis.vector, -rotationAboutAxis.scalar);
-    }
 
-    // Normalize twist feedback in units of turns
-    double angleAboutAxis = 2 * std::acos (rotationAboutAxis.scalar);
+    // Calculate rotation across the axis in global coordinates
+    double dotProduct = deltaQuaternion.vector * projection.vector;
 
-    double twist = ! isnan (previousAngleAboutAxis)
-                       ? std::fmod (angleAboutAxis - previousAngleAboutAxis + 3 * MathConstants<double>::pi, MathConstants<double>::twoPi) - MathConstants<double>::pi
-                       : 0;
+    double incrementalAngle = 2*std::atan2 (dotProduct, deltaQuaternion.scalar);
 
-    previousAngleAboutAxis = angleAboutAxis;
+    return incrementalAngle / MathConstants<double>::twoPi;
 
-    return -twist / MathConstants<double>::twoPi;
 }
 
 void CommutatorThread::hiResTimerCallback()
@@ -148,7 +144,12 @@ void CommutatorThread::hiResTimerCallback()
     if (currentQuaternion == defaultQuaternion)
         return;
 
-    double currentTwist = quaternionToTwist (Quaternion<double> (currentQuaternion[1], currentQuaternion[2], currentQuaternion[3], currentQuaternion[0]));
+    double currentTwist = 0;
+    if (lastQuaternion != defaultQuaternion)
+        currentTwist = quaternionToTwist (Quaternion<double> (currentQuaternion[1], currentQuaternion[2], currentQuaternion[3], currentQuaternion[0]).normalised(),
+                                          Quaternion<double> (lastQuaternion[1], lastQuaternion[2], lastQuaternion[3], lastQuaternion[0]).normalised());
+
+    lastQuaternion = currentQuaternion;
 
     if (! isnan (lastTwist))
     {

--- a/Source/CommutatorThread.h
+++ b/Source/CommutatorThread.h
@@ -46,13 +46,13 @@ public:
 
 private:
     /** Converts quaternion data to a twist. Quaternion values are expected to be ordered X/Y/Z/W. */
-    double quaternionToTwist (Quaternion<double> quaternion);
+    double quaternionToTwist (Quaternion<double> currentQuaternion, Quaternion<double> lastQuaternion);
     void sendTurn (double turn);
 
     ofSerial serial;
 
     double lastTwist = std::numeric_limits<double>::quiet_NaN();
-    double previousAngleAboutAxis = std::numeric_limits<double>::quiet_NaN();
+    std::array<double, 4> lastQuaternion;
 
     static inline const std::array<double, 4> defaultQuaternion { 0.0, 0.0, 0.0, 0.0 };
 


### PR DESCRIPTION
Implements a more robust quaternion to turn algorithm.

Not sure if this should be a patch or minor version increase

With this change, the axis selector on the plugin properly defines which axis on the IMU, from its physical representation, is to be used for turning computations. 